### PR TITLE
add .editorconfig with `insert_final_newline = true` and other settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = LF
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{Makefile,.SRCINFO}]
+indent_style = tab


### PR DESCRIPTION
Hopefully the `insert_final_newline = true` setting will help VS Code realize it should include the end-of-file newline.