### PR TITLE
fix error when `show` subcommand called without its own subcommand

### DIFF
--- a/rust/src/cmd/show.rs
+++ b/rust/src/cmd/show.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
 use procurve_cli::ProCurveClient;
 
-use clap::{App, ArgMatches};
+use clap::{App, AppSettings, ArgMatches};
 
 pub fn make_subcommand<'a>() -> App<'a> {
     App::new("show")
         .about("Shows switch settings")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
             App::new("description").about("Show model, firmware version, contact info, etc."),
         )


### PR DESCRIPTION
Fixes:

    $ RUST_BACKTRACE=1 SWITCH_URL=1 ./target/debug/procurve-cli show                                                                          :(
    thread 'main' panicked at 'internal error: entered unreachable code', src/cmd/show.rs:21:14
    stack backtrace:
       0: rust_begin_unwind
                 at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:517:5
       1: core::panicking::panic_fmt
                 at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/panicking.rs:101:14
       2: core::panicking::panic
                 at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/panicking.rs:50:5
       3: procurve_cli::cmd::show::execute
                 at ./rust/src/cmd/show.rs:21:14
       4: procurve_cli::main
                 at ./rust/src/main.rs:17:40
       5: core::ops::function::FnOnce::call_once
                 at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/core/src/ops/function.rs:227:5